### PR TITLE
feat: boundary cell style

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ const data = [
   start="2020-04-04"
   end="2023-05-19"
   textColor="#000000"
+  includeBoundary={true}
   theme="grass"
 />
 ```
@@ -84,6 +85,7 @@ const data = [
 - `start`: Optional. The starting date for the calendar to start, defaults to current year's January 1st(`YYYY-MM-DD` format).
 - `end`: Optional. The ending date for the calendar to end, defaults to current year's December 31st(`YYYY-MM-DD` format).
 - `textColor`: Optional. The color of indexes. String color code format. 
+- `includeBoundary`: Optional. Whethere to include the boundary cells in the starting or ending date column, defaults to `true`.
 - `theme`: Optional. A string that represents a predefined theme name, or an object with custom theme colors. Defaults to `grass`.
 
 <br />   

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-contribution-calendar",
   "description": "A GitHub-like contribution calendar component for React",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/types/react-contribution-calendar.d.ts",

--- a/src/components/Table/index.tsx
+++ b/src/components/Table/index.tsx
@@ -9,6 +9,7 @@ interface TableProps {
   theme?: string | ThemeProps
   start?: string
   end?: string
+  includeBoundary?: boolean
 }
 
 export default function Table({
@@ -17,12 +18,20 @@ export default function Table({
   theme = 'grass',
   start = getDateString(getCurrentYear(), 0, 1),
   end = getDateString(getCurrentYear(), 11, 31),
+  includeBoundary = true,
 }: TableProps) {
   return (
     <div className="container">
       <table>
         <TableHead textColor={textColor} start={start} end={end} />
-        <TableBody data={data} textColor={textColor} theme={theme} start={start} end={end} />
+        <TableBody
+          data={data}
+          textColor={textColor}
+          theme={theme}
+          start={start}
+          end={end}
+          includeBoundary={includeBoundary}
+        />
       </table>
     </div>
   )

--- a/src/components/TableBody/index.tsx
+++ b/src/components/TableBody/index.tsx
@@ -15,9 +15,10 @@ interface TableBodyProps {
   end: string
   textColor: string
   theme: string | ThemeProps
+  includeBoundary: boolean
 }
 
-export default function TableBody({ data, start, end, textColor, theme }: TableBodyProps) {
+export default function TableBody({ data, start, end, textColor, theme, includeBoundary }: TableBodyProps) {
   const startYear = parseYearFromDateString(start)
 
   const { row: startRow, col: startCol } = getRowAndColumnIndexFromDate(startYear, start)
@@ -33,8 +34,8 @@ export default function TableBody({ data, start, end, textColor, theme }: TableB
   const themeProps = setColorByTheme(theme)
   const parsedData = parseInputData(data)
 
-  const isOutRangedCell = (rowIndex: number, colIndex: number): boolean => {
-    return !dayArray[rowIndex][colIndex] || colIndex < startCol || colIndex > endCol
+  const isOutRangedCell = (_: number, colIndex: number): boolean => {
+    return colIndex < startCol || colIndex > endCol
   }
 
   const isBoundaryCell = (rowIndex: number, colIndex: number): boolean => {
@@ -59,7 +60,7 @@ export default function TableBody({ data, start, end, textColor, theme }: TableB
                   key={colIndex}
                   style={{
                     padding: 0,
-                    outline: '1px solid rgba(27, 31, 35, 0.06)',
+                    outline: includeBoundary ? '1px solid rgba(27, 31, 35, 0.06)' : 'none',
                     borderRadius: '2px',
                     outlineOffset: '-1px',
                     shapeRendering: 'geometricPrecision',

--- a/src/types/react-contribution-calendar.d.ts
+++ b/src/types/react-contribution-calendar.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-contribution-calendar 1.1.1
+// Type definitions for react-contribution-calendar 1.1.2
 // Project: https://github.com/seiwon-yaehee/react-contribution-calendar
 // Definitions by: Seiwon Park <https://github.com/SeiwonPark>
 //                 Yaehee Choe <https://github.com/YaeheeChoe>
@@ -36,6 +36,10 @@ declare module 'react-contribution-calendar' {
      * The text color of calendar indexes for months and dates, defaults to `#000`.
      */
     textColor?: string
+    /**
+     * Whether to include the boundary column or not, defaults to `true`.
+     */
+    includeBoundary?: boolean
     /**
      * The name of theme for the ContributionCalendar, defaults to `grass`. Also
      * `ThemeProps` could be added directly i.e. when trying to use custom theme.


### PR DESCRIPTION
## What's been updated

Now, the boundary column for the starting and ending date could be ignored.

```typescript
<ContributionCalendar
  data={[]}
  includeBoundary={true}  // <------ Added. Defaults to `true`
/>
```

|`includeBoundary={true}`|`includeBoundary={false}`|
|:-------------------------:|:-------------------------:|
|<img width="283" alt="Screenshot 2023-08-16 at 3 01 54 PM" src="https://github.com/seiwon-yaehee/react-contribution-calendar/assets/63793178/6aa9097f-2372-4668-8047-5a98e7f0fcb9">|<img width="283" alt="Screenshot 2023-08-16 at 3 01 43 PM" src="https://github.com/seiwon-yaehee/react-contribution-calendar/assets/63793178/9f039038-9752-4b4e-bf95-35d96907da7f">|
